### PR TITLE
VSCodetextlint拡張機能の移行

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,10 @@
     },
 
     "extensions": [
-		"yzhang.markdown-all-in-one",
-		"3w36zj6.textlint",
-		"james-yu.latex-workshop",
-		"yzane.markdown-pdf",
-	    "davidanson.vscode-markdownlint"
-	]
+        "yzhang.markdown-all-in-one",
+        "3w36zj6.textlint",
+        "james-yu.latex-workshop",
+        "yzane.markdown-pdf",
+        "davidanson.vscode-markdownlint"
+    ]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
 
     "extensions": [
 		"yzhang.markdown-all-in-one",
-		"taichi.vscode-textlint",
+		"3w36zj6.textlint",
 		"james-yu.latex-workshop",
 		"yzane.markdown-pdf",
-	        "davidanson.vscode-markdownlint"
+	    "davidanson.vscode-markdownlint"
 	]
 }


### PR DESCRIPTION
現在用いているVSCodeのtextlint拡張機能が非推奨になっているため、推奨される先に移行する