### PR TITLE
インストールするルール名をwhitelistからallowlistに変更

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y git
 RUN npm install -g textlint \
     textlint-filter-rule-comments \
     textlint-filter-rule-node-types \
-    textlint-filter-rule-whitelist \
+    textlint-filter-rule-allowlist \
     textlint-plugin-review \
     textlint-rule-max-ten \
     textlint-rule-no-mix-dearu-desumasu \


### PR DESCRIPTION
ルールのパッケージ名が過去に変更されているため、インストールするパッケージ名を変更

https://github.com/textlint/textlint-filter-rule-allowlist/pull/9