### PR TITLE
textlintルールの見直し

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -11,9 +11,7 @@
             "nodeTypes": ["Inline", "Link"]
         }
     },
-    "rules": {
-        "no-mix-dearu-desumasu": true,
-        
+    "rules": {        
         "preset-japanese": {
             "sentence-length": {
                 "max": 150

--- a/.textlintrc
+++ b/.textlintrc
@@ -18,9 +18,6 @@
             "sentence-length": {
                 "max": 150
             },
-            "max-ten": {
-                "max": 4
-            },
             "no-doubled-joshi": {
                 "min_interval" : 1,
                 "strict": false,


### PR DESCRIPTION
このPRでは.textlintrcのルール見直しを行っています。

- 変更点

max-tenの数は4つまでとしていましたが、4つも点を使う文は冗長なため、デフォルト値の3つに制限しました。

no-mix-dearu-desumasuは、既にpreset-japanese及びpreset-jtf-styleに文体の統一が含まれているため削除しました。

- 備考

preset-japaneseを削除してtextlint-rule-preset-ja-technical-writingを適用するか検討中です

#9 の変更を取り込んだ後package.jsonから不要な依存関係を削除して正式なPRとして提出する予定です。